### PR TITLE
feat: Added Hot Water Accessory

### DIFF
--- a/src/tado-hotwater-zone.js
+++ b/src/tado-hotwater-zone.js
@@ -1,0 +1,143 @@
+/**
+ * Represents a hot water zone in Tado.
+ * @param platform The TadoPlatform instance.
+ * @param apiZone The zone from the API.
+ */
+function TadoHotWaterZone(platform, apiZone) {
+    const zone = this;
+    const { UUIDGen, Accessory, Characteristic, Service } = platform;
+
+    // Sets the ID and platform
+    zone.id = apiZone.id;
+    zone.platform = platform;
+
+    // Gets all accessories from the platform that match the zone ID
+    let unusedZoneAccessories = platform.accessories.filter(function(a) { return a.context.id === zone.id; });
+    let newZoneAccessories = [];
+    let zoneAccessories = [];
+
+    // Gets the thermostat accessory
+    let hotWaterAccessory = unusedZoneAccessories.find(function(a) { return a.context.kind === 'HotWaterAccessory'; });
+    if (hotWaterAccessory) {
+        unusedZoneAccessories.splice(unusedZoneAccessories.indexOf(hotWaterAccessory), 1);
+    } else {
+        platform.log('Adding new accessory with zone ID ' + zone.id + ' and kind HotWaterAccessory.');
+        hotWaterAccessory = new Accessory(apiZone.name, UUIDGen.generate(zone.id + 'HotWaterAccessory'));
+        hotWaterAccessory.context.id = zone.id;
+        hotWaterAccessory.context.kind = 'HotWaterAccessory';
+        newZoneAccessories.push(hotWaterAccessory);
+    }
+    zoneAccessories.push(hotWaterAccessory);
+
+    // Registers the newly created accessories
+    platform.api.registerPlatformAccessories(platform.pluginName, platform.platformName, newZoneAccessories);
+
+    // Removes all unused accessories
+    for (let i = 0; i < unusedZoneAccessories.length; i++) {
+        const unusedZoneAccessory = unusedZoneAccessories[i];
+        platform.log('Removing unused accessory with zone ID ' + unusedZoneAccessory.context.id + ' and kind ' + unusedZoneAccessory.context.kind + '.');
+        platform.accessories.splice(platform.accessories.indexOf(unusedZoneAccessory), 1);
+    }
+    platform.api.unregisterPlatformAccessories(platform.pluginName, platform.platformName, unusedZoneAccessories);
+
+    // Gets the zone leader
+    const zoneLeader = apiZone.devices.find(function(d) { return d.duties.some(function(duty) { return duty === 'ZONE_LEADER'; }); });
+    if (!zoneLeader) {
+        zoneLeader = apiZone.devices[0];
+    }
+
+    // Updates the accessory information
+    for (let i = 0; i < zoneAccessories.length; i++) {
+        const zoneAccessory = zoneAccessories[i];
+        let accessoryInformationService = zoneAccessory.getService(Service.AccessoryInformation);
+        if (!accessoryInformationService) {
+            accessoryInformationService = zoneAccessory.addService(Service.AccessoryInformation);
+        }
+        accessoryInformationService
+            .setCharacteristic(Characteristic.Manufacturer, 'Tado')
+            .setCharacteristic(Characteristic.Model, zoneLeader.deviceType)
+            .setCharacteristic(Characteristic.SerialNumber, zoneLeader.serialNo)
+            .setCharacteristic(Characteristic.FirmwareRevision, zoneLeader.currentFwVersion);
+    }
+
+    // Updates the hot water service
+    let hotWaterService = hotWaterAccessory.getServiceByUUIDAndSubType(Service.Switch);
+    if (!hotWaterService) {
+        hotWaterService = hotWaterAccessory.addService(Service.Switch);
+    }
+
+    // Stores the hot water service
+    zone.hotWaterService = hotWaterService;
+
+    // Subscribes for changes of the target state characteristic
+    hotWaterService.getCharacteristic(Characteristic.On).on('set', function (value, callback) {
+        // Sets the state to ON
+        if (value === true) {
+            platform.log.debug(zone.id + ' - Switch target state to HEATING');
+            zone.platform.client.setZoneOverlay(platform.home.id, zone.id, 'on', hotWaterService.getCharacteristic(Characteristic.On).value, platform.config.switchToAutoInNextTimeBlock ? 'auto' : 'manual').then(function() {
+                // Updates the state
+                zone.updateState();
+            }, function() {
+                platform.log(zone.id + ' - Failed to switch target state to ON');
+            });
+        }
+
+        // Sets the state to OFF
+        if (value === false) {
+            platform.log.debug(zone.id + ' - Switch target state to AUTO');
+            zone.platform.client.clearZoneOverlay(platform.home.id, zone.id).then(function() {
+                // Updates the state
+                zone.updateState();
+            }, function() {
+                platform.log(zone.id + ' - Failed to switch target state to OFF');
+            });
+        }
+
+        // Performs the callback
+        callback(null);
+    });
+
+    // Sets the interval for the next update
+    setInterval(function() { zone.updateState(); }, zone.platform.config.stateUpdateInterval * 1000);
+
+    // Updates the state initially
+    zone.updateState();
+}
+
+/**
+ * Can be called to update the zone state.
+ */
+TadoHotWaterZone.prototype.updateState = function () {
+    const zone = this;
+    const { Characteristic } = zone.platform;
+
+    // Calls the API to update the state
+    zone.platform.client.getZoneState(zone.platform.home.id, zone.id).then(function(state) {
+        const apiZone = zone.platform.apiZones.find(function(z) { return z.id === zone.id; });
+        apiZone.state = state;
+
+        // Updates the target state
+        zone.hotWaterService.updateCharacteristic(Characteristic.On, state.setting.power === 'ON');
+        
+        zone.platform.log.debug(zone.id + ' - Updated state.');
+        zone.platform.log.debug(zone.id + ' - new state: ' + JSON.stringify(state));
+    }, function() {
+        zone.platform.log(zone.id + ' - Error getting state from API.');
+    });
+}
+
+/**
+ * Can be called to update the zone.
+ */
+TadoHotWaterZone.prototype.updateZone = function (apiZones) {
+    const zone = this;
+    const { Characteristic } = zone.platform;
+
+    // Gets the zone that this instance represents
+    const apiZone = apiZones.find(function(z) { return z.id === zone.id; });
+}
+
+/**
+ * Defines the export of the file.
+ */
+module.exports = TadoHotWaterZone;

--- a/src/tado-platform.js
+++ b/src/tado-platform.js
@@ -2,6 +2,7 @@
 const Tado = require('node-tado-client');
 
 const TadoHeatingZone = require('./tado-heating-zone');
+const TadoHotWaterZone = require('./tado-hotwater-zone');
 const TadoMobileDevice = require('./tado-mobile-device');
 const TadoHomeDevice = require('./tado-home-device');
 const TadoApi = require('./tado-api');
@@ -105,6 +106,13 @@ function TadoPlatform(log, config, api) {
                         if (apiZone.type === 'HEATING') {
                             platform.log('Create heating zone with ID ' + apiZone.id + ' and name ' + apiZone.name + '.');
                             const zone = new TadoHeatingZone(platform, apiZone);
+                            platform.zones.push(zone);
+                        }
+                        
+                        // Adds the hot water zone
+                        if (apiZone.type === 'HOT_WATER') {
+                            platform.log('Create hot water zone with ID ' + apiZone.id + ' and name ' + apiZone.name + '.');
+                            const zone = new TadoHotWaterZone(platform, apiZone);
                             platform.zones.push(zone);
                         }
                     }


### PR DESCRIPTION
Hot water control through the Tado platform is provided through the optional Tado Extension Kit (https://www.tado.com/gb/products/extension-kit). This is a device which is directly connected to the boiler instead of a Tado Smart Thermostat and is therefore powered through the mains. Along with enabling hot water control, the Extension Kit allows users to connect the Tado platform with wireless thermostats.

Hot water control is a simple ON/OFF relay switch and the Tado Extension Kit cannot control water temperature due to the hot water thermostat being a "dumb" device physically attached to the water tank which in turn is linked directly to the boiler.

The Tado API accepts a PUT onto the overlay endpoint to switch on hot water (with the Extension Kit expected to be at zone/0) and a DELETE to turn off.