### PR TITLE
Support for termination options for individual zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ npm install -g homebridge-tado-smart-thermostat
                     "zoneId": <YOUR-ZONE-ID>,
                     "zoneName": "<YOUR-ZONE-NAME>",
                     "terminationOption": "auto"
-                }]
+                }
+            ]
     }
 ```
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ npm install -g homebridge-tado-smart-thermostat
 
 **apiToken** (optional): The token that has to be included in each request of the API. Is required if the API is enabled and has no default value.
 
-**zones** (optional): if you wish to override the switchToAutoInNextTimeBlock for a particular zone, add each zone by ID and with terminationOption of auto, manual or the number of minutes the change should last. Zone Name is purely for readability.
+**zones** (optional): If you wish to override the default termination (until next automatic change, until cancelled by user or a timer) for a particular zone, add each zone by ID (IDs are printed in the log during Homebridge startup) with terminationOption of "auto", "manual" or the number of minutes the change should last. Zone Name is purely for readability.
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -51,9 +51,13 @@ npm install -g homebridge-tado-smart-thermostat
             "isApiEnabled": false,
             "apiPort": 40810,
             "apiToken": "<YOUR-TOKEN>"
-        }
-    ]
-}
+            "zones": [
+                {
+                    "zoneId": <YOUR-ZONE-ID>,
+                    "zoneName": "<YOUR-ZONE-NAME>",
+                    "terminationOption": "auto"
+                }]
+    }
 ```
 
 **username**: The user name that you use for the app and the web app of Tado.
@@ -85,6 +89,8 @@ npm install -g homebridge-tado-smart-thermostat
 **apiPort** (optional): The port that the API (if enabled) runs on. Defaults to `40810`, please change this setting of the port is already in use.
 
 **apiToken** (optional): The token that has to be included in each request of the API. Is required if the API is enabled and has no default value.
+
+**zones** (optional): if you wish to override the switchToAutoInNextTimeBlock for a particular zone, add each zone by ID and with terminationOption of auto, manual or the number of minutes the change should last. Zone Name is purely for readability.
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ npm install -g homebridge-tado-smart-thermostat
                     "zoneName": "<YOUR-ZONE-NAME>",
                     "terminationOption": "auto"
                 }
+                ]
+            }
             ]
     }
 ```

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ npm install -g homebridge-tado-smart-thermostat
             "homeUpdateInterval": 60,
             "isApiEnabled": false,
             "apiPort": 40810,
-            "apiToken": "<YOUR-TOKEN>"
+            "apiToken": "<YOUR-TOKEN>",
             "zones": [
                 {
                     "zoneId": <YOUR-ZONE-ID>,

--- a/src/tado-heating-zone.js
+++ b/src/tado-heating-zone.js
@@ -112,13 +112,31 @@ function TadoHeatingZone(platform, apiZone) {
     // Stores the contact sensor service
     zone.contactSensorService = contactSensorService;
 
+    // Sets termination variable from zone config
+    var terminationOption;
+    for (var i = 0; i < platform.config.zones.length; i++){
+        if (platform.config.zones[i].zoneId == zone.id){
+            break;
+        }
+    }
+    var termination = 'manual';
+    if (terminationOption == null && platform.config.switchToAutoInNextTimeBlock) {
+        termination =  'auto';
+    }
+    else if (!isNaN(parseInt(terminationOption))) {
+        termination = terminationOption * 60;
+    }
+    else{
+        termination = terminationOption;
+    }
+
     // Subscribes for changes of the target state characteristic
     thermostatService.getCharacteristic(Characteristic.TargetHeatingCoolingState).on('set', function (value, callback) {
 
         // Sets the state to OFF
         if (!value) {
             platform.log.debug(zone.id + ' - Switch target state to OFF');
-            zone.platform.client.setZoneOverlay(platform.home.id, zone.id, 'off', thermostatService.getCharacteristic(Characteristic.TargetTemperature).value, platform.config.switchToAutoInNextTimeBlock ? 'auto' : 'manual').then(function() {
+            zone.platform.client.setZoneOverlay(platform.home.id, zone.id, 'off', thermostatService.getCharacteristic(Characteristic.TargetTemperature).value, termination).then(function() {
 
                 // Updates the state
                 zone.updateState();
@@ -130,7 +148,7 @@ function TadoHeatingZone(platform, apiZone) {
         // Sets the state to HEATING
         if (value === 1) {
             platform.log.debug(zone.id + ' - Switch target state to HEATING');
-            zone.platform.client.setZoneOverlay(platform.home.id, zone.id, 'on', thermostatService.getCharacteristic(Characteristic.TargetTemperature).value, platform.config.switchToAutoInNextTimeBlock ? 'auto' : 'manual').then(function() {
+            zone.platform.client.setZoneOverlay(platform.home.id, zone.id, 'on', thermostatService.getCharacteristic(Characteristic.TargetTemperature).value, termination).then(function() {
 
                 // Updates the state
                 zone.updateState();
@@ -160,7 +178,7 @@ function TadoHeatingZone(platform, apiZone) {
 
         // Sets the target temperature
         platform.log.debug(zone.id + ' - Set target temperature to ' + value);
-        zone.platform.client.setZoneOverlay(platform.home.id, zone.id, 'on', value, platform.config.switchToAutoInNextTimeBlock ? 'auto' : 'manual').then(function() {
+        zone.platform.client.setZoneOverlay(platform.home.id, zone.id, 'on', value, termination).then(function() {
 
             // Updates the state
             zone.updateState();

--- a/src/tado-heating-zone.js
+++ b/src/tado-heating-zone.js
@@ -116,6 +116,7 @@ function TadoHeatingZone(platform, apiZone) {
     var terminationOption;
     for (var i = 0; i < platform.config.zones.length; i++){
         if (platform.config.zones[i].zoneId == zone.id){
+            terminationOption = platform.config.zones[i].terminationOption;
             break;
         }
     }

--- a/src/tado-platform.js
+++ b/src/tado-platform.js
@@ -52,6 +52,7 @@ function TadoPlatform(log, config, api) {
     platform.config.isApiEnabled = platform.config.isApiEnabled || false;
     platform.config.apiPort = platform.config.apiPort || 40810;
     platform.config.apiToken = platform.config.apiToken || null;
+	platform.config.zones = platform.config.zones || [];
 
     // Checks whether the API object is available
     if (!api) {


### PR DESCRIPTION
Adds the option to add individual zones to your config file with different termination options, for example: manual, auto or the time to termination in minutes.