### PR TITLE
Hide API options if API is not enabled

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -97,12 +97,18 @@
               "type": "integer",
               "title": "API Port",
               "placeholder": "40810",
-              "description": "The port that the API (if enabled) runs on. Defaults to 40810, please change this setting of the port is already in use."
+              "description": "The port that the API (if enabled) runs on. Defaults to 40810, please change this setting of the port is already in use.",
+              "condition": {
+                "functionBody": "return model.isApiEnabled === true;"
+              }
             },
             "apiToken": {
               "type": "string",
               "title": "API Token",
-              "description": "The token that has to be included in each request of the API. Is required if the API is enabled and has no default value."
+              "description": "The token that has to be included in each request of the API. Is required if the API is enabled and has no default value.",
+              "condition": {
+                "functionBody": "return model.isApiEnabled === true;"
+              }              
             },
             "zones": {
                 "type": "array",


### PR DESCRIPTION
Just a convenience thing. This change adds a conditional to the schema to hide the API settings, if the API is not enabled.